### PR TITLE
board/pluto: fix MSD wiki links

### DIFF
--- a/board/pluto/msd/index.html
+++ b/board/pluto/msd/index.html
@@ -66,7 +66,7 @@
 <section id="firmware">
 <a class="anchor" href="#top">Back to top</a>
 <h3>Firmware</h3>
-<p>ADALM-PLUTO Firmware refers to the U-Boot, HDL, Linux kernel, device drivers, and userspace software, that runs on the PlutoSDR which enales the device to communicate to USB host. This is bundled up and given a specific version number for the ADALM-PLUTO device. For help upgrading firmware, check out the <a href="https://wiki.analog.com/university/tools/pluto/common/firmware">online documentation</a>.</p>
+<p>ADALM-PLUTO Firmware refers to the U-Boot, HDL, Linux kernel, device drivers, and userspace software, that runs on the PlutoSDR which enales the device to communicate to USB host. This is bundled up and given a specific version number for the ADALM-PLUTO device. For help upgrading firmware, check out the <a href="https://wiki.analog.com/university/tools/pluto/users/firmware">online documentation</a>.</p>
 <div id="versionsection" class="download">
 <p><strong>Status of the PlutoSDR firmware:</strong></p>
 <p><span id="versiontest">Need javascript to check (sorry)</span></p>
@@ -178,7 +178,7 @@
 </tbody>
 </table>
 
-<p>To change these settings, check the <a href="https://wiki.analog.com/university/tools/pluto/common/customizing">on-line documentation</a>.</p>
+<p>To change these settings, check the <a href="https://wiki.analog.com/university/tools/pluto/users/customizing">on-line documentation</a>.</p>
 </section>
 <hr>
 <section id="support">


### PR DESCRIPTION
Fix two dead links to the documentation wiki in the MSD index page. The regulatory compliance wiki link is also dead, but I can not find the page that was supposed to reference.