### PR TITLE
 pluto,m2k,sidekiqz2: add mtools package and make post-build scripts fail early if something went wrong

### DIFF
--- a/board/m2k/post-build.sh
+++ b/board/m2k/post-build.sh
@@ -32,8 +32,8 @@ genimage                           \
 	--outputpath "${TARGET_DIR}/opt/" \
 	--config "${GENIMAGE_CFG}"
 
-rm ${TARGET_DIR}/opt/boot.vfat
-rm ${TARGET_DIR}/etc/init.d/S99iiod
+rm -f ${TARGET_DIR}/opt/boot.vfat
+rm -f ${TARGET_DIR}/etc/init.d/S99iiod
 
 mkdir -p ${TARGET_DIR}/www/img
 mkdir -p ${TARGET_DIR}/mnt_jffs2

--- a/board/m2k/post-build.sh
+++ b/board/m2k/post-build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # args from BR2_ROOTFS_POST_SCRIPT_ARGS
 # $2    board name
+set -e
 
 INSTALL=install
 

--- a/board/pluto/post-build.sh
+++ b/board/pluto/post-build.sh
@@ -30,8 +30,8 @@ genimage                           \
 	--outputpath "${TARGET_DIR}/opt/" \
 	--config "${GENIMAGE_CFG}"
 
-rm ${TARGET_DIR}/opt/boot.vfat
-rm ${TARGET_DIR}/etc/init.d/S99iiod
+rm -f ${TARGET_DIR}/opt/boot.vfat
+rm -f ${TARGET_DIR}/etc/init.d/S99iiod
 
 mkdir -p ${TARGET_DIR}/www/img
 mkdir -p ${TARGET_DIR}/etc/wpa_supplicant/

--- a/board/pluto/post-build.sh
+++ b/board/pluto/post-build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # args from BR2_ROOTFS_POST_SCRIPT_ARGS
 # $2    board name
+set -e
 
 INSTALL=install
 

--- a/board/sidekiqz2/post-build.sh
+++ b/board/sidekiqz2/post-build.sh
@@ -30,8 +30,8 @@ genimage                           \
 	--outputpath "${TARGET_DIR}/opt/" \
 	--config "${GENIMAGE_CFG}"
 
-rm ${TARGET_DIR}/opt/boot.vfat
-rm ${TARGET_DIR}/etc/init.d/S99iiod
+rm -f ${TARGET_DIR}/opt/boot.vfat
+rm -f ${TARGET_DIR}/etc/init.d/S99iiod
 
 mkdir -p ${TARGET_DIR}/www/img
 mkdir -p ${TARGET_DIR}/etc/wpa_supplicant/

--- a/board/sidekiqz2/post-build.sh
+++ b/board/sidekiqz2/post-build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # args from BR2_ROOTFS_POST_SCRIPT_ARGS
 # $2    board name
+set -e
 
 INSTALL=install
 

--- a/package/genimage/genimage.mk
+++ b/package/genimage/genimage.mk
@@ -7,7 +7,7 @@
 GENIMAGE_VERSION = 9
 GENIMAGE_SOURCE = genimage-$(GENIMAGE_VERSION).tar.xz
 GENIMAGE_SITE = https://github.com/pengutronix/genimage/releases/download/v$(GENIMAGE_VERSION)
-HOST_GENIMAGE_DEPENDENCIES = host-pkgconf host-libconfuse
+HOST_GENIMAGE_DEPENDENCIES = host-pkgconf host-libconfuse host-mtools
 GENIMAGE_LICENSE = GPL-2.0
 GENIMAGE_LICENSE_FILES = COPYING
 


### PR DESCRIPTION
The `mcopy` command fails silently [in the post-build script] if it's not present.
This probably worked because mtools was installed host-side via distro's package manager.
The `genimage` package relies on `mcopy` to generate the `vfat.img`  (the partition that is mounted on the host from the device).

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>