### PR TITLE
S45msd : indicate if one or two cores are enabled.

### DIFF
--- a/board/pluto/S45msd
+++ b/board/pluto/S45msd
@@ -8,7 +8,7 @@ file=/sys/kernel/config/usb_gadget/composite_gadget/functions/mass_storage.0/lun
 img=/opt/vfat.img
 
 patch_html_page() {
-	LINUX=`uname -a | tr / -`
+	LINUX=`uname -a | tr / - | tr '\n' ';' ; echo -n $(nproc) "core(s)"`
 	MODEL=`cat /sys/firmware/devicetree/base/model | tr / -`
 	SERIAL=`cat /sys/kernel/config/usb_gadget/composite_gadget/strings/0x409/serialnumber`
 	MACHOST=`cat /sys/kernel/config/usb_gadget/composite_gadget/functions/rndis.0/host_addr`


### PR DESCRIPTION
Although we use the single core version of the Xilinx 7010, many people are turning on the second core, so let them know if it is working.

Signed-off-by: Robin Getz <robin.getz@analog.com>