### PR TITLE
S23udc, S45msd : Tell users if it is a AD9364, or a AD9363

### DIFF
--- a/board/pluto/S23udc
+++ b/board/pluto/S23udc
@@ -12,8 +12,21 @@ create_iiod_context_attributes() {
 	serial=$2
 	model_variant=$3
 
+	if [ "$USBPID" == "0xb673" ]; then
+		# ADALM-PLUTO
+		for dev in /sys/bus/iio/devices/*; do
+			[ `cat ${dev}/name` == "ad9361-phy" ] && DEV_NAME=`basename ${dev}`
+		done
+
+		AD936X_TYPE=$(cat /sys/bus/iio/devices/${DEV_NAME}/of_node/compatible | sed 's/adi,//g')
+		AD936X_TYPE_CAP=$(echo $AD936X_TYPE | tr a-z A-Z)
+		MODEL=$(echo $model | sed "s/AD936[34]/$AD936X_TYPE_CAP/")
+	else
+		MODEL=$model
+	fi
+
 	echo "[Context Attributes]" > /etc/libiio.ini
-	echo "hw_model=$model" >> /etc/libiio.ini
+	echo "hw_model=$MODEL" >> /etc/libiio.ini
 
 	if [ "$model_variant" == "n25q256a" ]
 	then
@@ -25,13 +38,8 @@ create_iiod_context_attributes() {
 	echo -e "hw_serial=$serial\n" >> /etc/libiio.ini
 	echo "fw_version=`grep device-fw /opt/VERSIONS | cut -d ' ' -f 2`" >> /etc/libiio.ini
 	if [ "$USBPID" == "0xb673" ]; then
-		# ADALM-PLUTO
-		for dev in /sys/bus/iio/devices/*; do
-			[ `cat ${dev}/name` == "ad9361-phy" ] && DEV_NAME=`basename ${dev}`
-		done
-
 		echo ad9361-phy,xo_correction=`cat /sys/bus/iio/devices/${DEV_NAME}/xo_correction` >> /etc/libiio.ini
-		echo ad9361-phy,model=`cat /sys/bus/iio/devices/${DEV_NAME}/of_node/compatible` | sed 's/adi,//g' >> /etc/libiio.ini
+		echo ad9361-phy,model=$AD936X_TYPE >> /etc/libiio.ini
 
 	elif [ "$USBPID" == "0xb672" ]; then
 		cat /opt/${CALIBFILENAME} | grep ^cal,* >> /etc/libiio.ini

--- a/board/pluto/S45msd
+++ b/board/pluto/S45msd
@@ -9,7 +9,7 @@ img=/opt/vfat.img
 
 patch_html_page() {
 	LINUX=`uname -a | tr / - | tr '\n' ';' ; echo -n $(nproc) "core(s)"`
-	MODEL=`cat /sys/firmware/devicetree/base/model | tr / -`
+	MODEL=`cat /etc/libiio.ini | grep hw_model= | cut -d '=' -f 2`
 	SERIAL=`cat /sys/kernel/config/usb_gadget/composite_gadget/strings/0x409/serialnumber`
 	MACHOST=`cat /sys/kernel/config/usb_gadget/composite_gadget/functions/rndis.0/host_addr`
 	MAC=`cat /sys/kernel/config/usb_gadget/composite_gadget/functions/rndis.0/dev_addr`


### PR DESCRIPTION
There are still a few AD9364 based PlutoSDR devices floating around,
and tell people if they have it or not.

This is a slightly different version of PR #9,
making sure the HTML and IIO context attribute MODEL strings are in sync.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>