### PR TITLE
index.html: allow end users to quickly tweet

### DIFF
--- a/board/pluto/msd/index.html
+++ b/board/pluto/msd/index.html
@@ -22,6 +22,9 @@
 <a href="http://www.analog.com">
 <img src="img/ADI_Logo_AWP.png" alt="Analog Devices logo" />
 </a>
+<div class="anchor">
+<a href="https://twitter.com/intent/tweet?text=Excited%20to%20try%20out%20my%20new%20@ADI_News%20%23plutosdr%20(ADALM-PLUTO%20http%3A%2F%2Fwww.analog.com%2Fplutosdr)%20Hands%20on%20Learning%20Module%20for%20Software%20Defined%20Radio%20pic.twitter.com%2F7JxgynEa8w&hashtags=matlab%2Cgnuradio%2Csdrangel%2Csdrsharp&related=twitter%3AADI_News" title="Click to Tweet">Share PlutoSDR: <img style="width: 32px;" src="./img/tw.png" alt="Twitter Logo"></a>
+</div>
 </header>
 
 <nav style="text-align: center;">


### PR DESCRIPTION
Add a url which allows a one button tweet for end users to share their
excitment of using the Pluto SDR.

Signed-off-by: Robin Getz <robin.getz@analog.com>