### PR TITLE
package: ad936x_ref_cal: add hash file with sha256 signatures

### DIFF
--- a/package/ad936x_ref_cal/ad936x_ref_cal.hash
+++ b/package/ad936x_ref_cal/ad936x_ref_cal.hash
@@ -1,0 +1,5 @@
+# Locally computed
+sha256 0e802442bad2fdedfbe9d0f39810e5358c30f1bc1ef85962d4efbcb93b7a742c ad936x_ref_cal-01747db5cd60ff64115a73ac1f3bb97911f5c58e.tar.gz
+
+# License files (locally computed as well)
+sha256 8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643 LICENSE


### PR DESCRIPTION
buildroot provides a warning that the LICENSE file has no hash.
This patch adds a SHA256 hash to the LICENSE file, and to the locally
generated archive.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>