### PR TITLE
dropbear: Host - enable linking with the shared libraries

### DIFF
--- a/package/dropbear/dropbear.mk
+++ b/package/dropbear/dropbear.mk
@@ -141,7 +141,7 @@ define DROPBEAR_INSTALL_TARGET_CMDS
 endef
 
 HOST_DROPBEAR_MAKE = \
-	$(MAKE) STATIC=1 \
+	$(MAKE) \
 	PROGRAMS="dropbearkey"
 
 $(eval $(autotools-package))


### PR DESCRIPTION
This fixes:

/usr/bin/ld: dbutil.o: in function `expand_homedir_path':
dbutil.c:(.text+0x996): warning: Using 'getpwuid' in statically linked
applications requires at runtime the shared libraries from the glibc
version used for linking
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/crtbeginT.o: relocation
R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when
making a PIE object
/usr/bin/ld: final link failed: nonrepresentable section on output

The issue was discovered on Debian Buster (10).

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>