### PR TITLE
Store ssh authorized_keys in jffs2

### DIFF
--- a/board/pluto/S21misc
+++ b/board/pluto/S21misc
@@ -20,6 +20,7 @@ case "$1" in
 		# Restore saved password and Dropbear keys
 		[[ -d /mnt/jffs2/etc ]] && cd /mnt/jffs2/etc && md5sum -s -c password.md5 && cp passwd shadow group /etc
 		[[ -d /mnt/jffs2/etc/dropbear ]] && cd /mnt/jffs2/etc/dropbear && md5sum -s -c keys.md5 && cp dropbear* /etc/dropbear/
+		[[ -d /mnt/jffs2/root/.ssh ]] && cd /mnt/jffs2/root/.ssh && md5sum -s -c keys.md5 && mkdir /root/.ssh && cp authorized_keys /root/.ssh
 		xo_correction
 		MAX_BS=`fw_printenv -n iio_max_block_size 2> /dev/null || echo 67108864`
 		echo ${MAX_BS} > /sys/module/industrialio_buffer_dma/parameters/max_block_size

--- a/board/pluto/device_persistent_keys
+++ b/board/pluto/device_persistent_keys
@@ -2,6 +2,7 @@
 set +e
 
 KEYFILE=/etc/dropbear/dropbear_ecdsa_host_key
+IDFILE=/root/.ssh/authorized_keys
 
 cat /proc/mounts | grep -q mtd2 || (echo "Filesystem not mounted use device_format_jffs2 command to setup your partition"; exit 1)
 
@@ -11,5 +12,8 @@ install -D ${KEYFILE} -t /mnt/jffs2/etc/dropbear
 cd /etc/dropbear
 md5sum dropbear* /etc/dropbear/ 2>/dev/null > /mnt/jffs2/etc/dropbear/keys.md5
 
-
-
+if [ -f ${IDFILE} ]; then
+ install -D ${IDFILE} -t /mnt/jffs2/root/.ssh
+ cd /root/.ssh
+ md5sum authorized_keys 2>/dev/null > /mnt/jffs2/root/.ssh/keys.md5
+fi


### PR DESCRIPTION
Allows persistent passwordless login to the pluto device.

```
# on your local machine
ssh-keygen 
ssh-copy-id root@pluto.local # login with your password
ssh root@pluto.local # should be no password prompt

# on your pluto device
device_format_jffs2 # if not done already
device_persistent_keys # stores host and user pubkey on jffs2
```