### PR TITLE
Allow space in SSID and wifi password

### DIFF
--- a/board/pluto/S40network
+++ b/board/pluto/S40network
@@ -54,7 +54,7 @@ create_system_files () {
 	then
 		if [ -n "$WLAN_PWD" ]
 		then
-			wpa_passphrase $WLAN_SSID $WLAN_PWD > /etc/wpa.conf
+			wpa_passphrase "$WLAN_SSID" "$WLAN_PWD" > /etc/wpa.conf
 		else
 			echo "network={" > /etc/wpa.conf
 			echo "    ssid=\"$WLAN_SSID\"" >> /etc/wpa.conf


### PR DESCRIPTION
The network script fails either the SSID or the wifi password has a space in it. This patch adds quotes around the SSID and the password, which will make it work correctly.