### PR TITLE
board: pluto & m2k: Temperature Look-up-table calib

### DIFF
--- a/board/m2k/S21misc
+++ b/board/m2k/S21misc
@@ -11,6 +11,10 @@ handle_calibration_files() {
 	elif [[ -s /mnt/jffs2/${CALIBFILENAME_FACTORY} ]]; then
 		cp /mnt/jffs2/${CALIBFILENAME_FACTORY} /opt/${CALIBFILENAME}
 	fi
+
+	if [[ -s /mnt/jffs2/${CALIBFILENAME_TEMP_LUT} ]]; then
+		cp /mnt/jffs2/${CALIBFILENAME_TEMP_LUT} /opt/${CALIBFILENAME_TEMP_LUT}
+	fi
 }
 
 case "$1" in

--- a/board/m2k/device_config
+++ b/board/m2k/device_config
@@ -14,4 +14,5 @@ FIRMWARE=/mnt/msd/m2k.frm
 FRM_MAGIC="ITB M2k (ADALM-2000)"
 CALIBFILENAME=m2k-calib.ini
 CALIBFILENAME_FACTORY=m2k-calib-factory.ini
+CALIBFILENAME_TEMP_LUT=m2k-calib-temp-lut.ini
 

--- a/board/pluto/S23udc
+++ b/board/pluto/S23udc
@@ -43,6 +43,7 @@ create_iiod_context_attributes() {
 
 	elif [ "$USBPID" == "0xb672" ]; then
 		cat /opt/${CALIBFILENAME} | grep ^cal,* >> /etc/libiio.ini
+		cat /opt/${CALIBFILENAME_TEMP_LUT} | grep ^cal,* >> /etc/libiio.ini
 	fi
 }
 

--- a/board/pluto/update.sh
+++ b/board/pluto/update.sh
@@ -248,6 +248,11 @@ do
 					do_reset=1
 			fi
 		fi
+
+		if [[ -s /mnt/msd/${CALIBFILENAME_TEMP_LUT} ]]; then
+			cp /mnt/msd/${CALIBFILENAME_TEMP_LUT} /mnt/jffs2/${CALIBFILENAME_TEMP_LUT}
+			do_reset=1
+		fi
 	fi
 
 	if [[ $do_reset = 1 ]]


### PR DESCRIPTION
This commit adds the possibility to load a look-up
table with calibration points using the USB mass storage
device into internal JFFS partition. The LUT data will
be exported at boot as an iio context attribute.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>