### PR TITLE
board/pluto/S40network: Fix typo in udhcpd.conf

### DIFF
--- a/board/pluto/S40network
+++ b/board/pluto/S40network
@@ -33,7 +33,7 @@ create_system_files () {
 
 	### /etc/udhcpd.conf ###
 	echo "start $IPADDR_HOST" > $UDHCPD_CONF
-	echo "end $IPADDR_HOST" > $UDHCPD_CONF
+	echo "end $IPADDR_HOST" >> $UDHCPD_CONF
 	echo "interface usb0" >> $UDHCPD_CONF
 	echo "option subnet $NETMASK" >> $UDHCPD_CONF
 


### PR DESCRIPTION
don't overwrite start.

Fixes: 509c896ac19e ("board/pluto/S40network: Compatibility with new busybox dhcpcd")