### PR TITLE
Update expat.mk with working download link

### DIFF
--- a/package/expat/expat.mk
+++ b/package/expat/expat.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 EXPAT_VERSION = 2.5.0
-EXPAT_SITE = http://downloads.sourceforge.net/project/expat/expat/$(EXPAT_VERSION)
+EXPAT_SITE = hhttps://github.com/libexpat/libexpat/releases/download/R_2_5_0/$(EXPAT_VERSION)
 EXPAT_SOURCE = expat-$(EXPAT_VERSION).tar.xz
 EXPAT_INSTALL_STAGING = YES
 EXPAT_LICENSE = MIT


### PR DESCRIPTION
Currently EXPAT fails during build. This is due to the link being outdated. New link is hosted at GitHub. This fixes the issue.