### PR TITLE
board/adi: update SPI UBI partition index

### DIFF
--- a/board/adi/patches/uboot/uboot.env
+++ b/board/adi/patches/uboot/uboot.env
@@ -1,7 +1,7 @@
 bootmenu_0=Boot SoM SPI flash=run sfboot
 bootmenu_1=Boot SoM eMMC=run emmcboot
 bootmenu=5
-sfboot=sf probe; sf read ${fdt_addr_r} 0x100000 0x9000; sf read ${kernel_addr_r} 0x110000 0xf00000; setenv bootargs ${bootargs} rootfstype=ubifs root=ubi0:rootfs ubi.mtd=4 rw; booti ${kernel_addr_r} - ${fdt_addr_r}
+sfboot=sf probe; sf read ${fdt_addr_r} 0x100000 0x9000; sf read ${kernel_addr_r} 0x110000 0xf00000; setenv bootargs ${bootargs} rootfstype=ubifs root=ubi0:rootfs ubi.mtd=3 rw; booti ${kernel_addr_r} - ${fdt_addr_r}
 emmcboot=fatload mmc 0:1 ${fdt_addr_r} /${fdtfile}; fatload mmc 0:1 ${kernel_addr_r} /Image; setenv bootargs ${bootargs} root=/dev/mmcblk0p2 rw rootfstype=ext4 rootwait; booti ${kernel_addr_r} - ${fdt_addr_r}
 bootargs=earlycon=adi_uart,0x31003000 console=ttySC0,115200 vmalloc=512M log_buf_len=4M
 kernel_addr_r=0x90009000


### PR DESCRIPTION
The SPI boot command hardcodes the UBI MTD partition index used for the root filesystem. With the newer Linux release, the device tree changes shifted the partition numbering, so `rootfs` is now exposed on `ubi.mtd=3` instead of `ubi.mtd=4`.

Update `sfboot` accordingly so SPI boot continues to mount the UBIFS root filesystem from the correct MTD partition.

This is a mandatory change due to https://github.com/analogdevicesinc/linux/commit/c400f44b36234bac524a12298c746a33d37beb4a