### PR TITLE
board/adi: fix u-boot load addresses for booti

### DIFF
--- a/board/adi/patches/uboot/uboot.env
+++ b/board/adi/patches/uboot/uboot.env
@@ -4,8 +4,9 @@ bootmenu=5
 sfboot=sf probe; sf read ${fdt_addr_r} 0x100000 0x9000; sf read ${kernel_addr_r} 0x110000 0xf00000; setenv bootargs ${bootargs} rootfstype=ubifs root=ubi0:rootfs ubi.mtd=3 rw; booti ${kernel_addr_r} - ${fdt_addr_r}
 emmcboot=fatload mmc 0:1 ${fdt_addr_r} /${fdtfile}; fatload mmc 0:1 ${kernel_addr_r} /Image; setenv bootargs ${bootargs} root=/dev/mmcblk0p2 rw rootfstype=ext4 rootwait; booti ${kernel_addr_r} - ${fdt_addr_r}
 bootargs=earlycon=adi_uart,0x31003000 console=ttySC0,115200 vmalloc=512M log_buf_len=4M
-kernel_addr_r=0x90009000
+kernel_addr_r=0x9a200000
 fdt_addr_r=0x90000000
+ramdisk_addr_r=0x9c000000
 fdtfile=sc598-som-ezkit.dtb
 ethaddr=02:80:ad:20:31:e8
 eth1addr=02:80:ad:20:31:e9


### PR DESCRIPTION
The default environment override baked kernel_addr_r=0x90009000, only 36 KB above fdt_addr_r=0x90000000. Every SC598 arm64 dtb is 37-38 KB, so loading the device tree at fdt_addr_r overran the kernel image head and corrupted its ARM64 magic.

ramdisk_addr_r was also missing, so initramfs boots that pass a ramdisk to booti used an unset variable.

Move kernel_addr_r to 0x9a200000 and add ramdisk_addr_r=0x9c000000, matching the upstream sc598-som-ezkit.env layout.