### PR TITLE
package/dropbear: add option to pre-generate SSH host keys

### DIFF
--- a/package/dropbear/Config.in
+++ b/package/dropbear/Config.in
@@ -74,4 +74,17 @@ config BR2_PACKAGE_DROPBEAR_LOCALOPTIONS_FILE
 	  localoptions.h. It can be used to tweak the Dropbear
 	  configuration.
 
+config BR2_PACKAGE_DROPBEAR_PREGENERATED_KEYS
+	bool "pre-generate SSH host keys"
+	select BR2_PACKAGE_HOST_DROPBEAR
+	help
+	  Generate the SSH host keys at build time and ship them in the
+	  image, instead of letting dropbear generate them on the first
+	  boot. Use this when the root filesystem is not persistent (e.g.
+	  an initramfs) but the host keys must stay the same across
+	  reboots.
+
+	  This replaces the /etc/dropbear -> /var/run/dropbear symlink with
+	  a real directory containing the keys.
+
 endif

--- a/package/dropbear/dropbear.mk
+++ b/package/dropbear/dropbear.mk
@@ -142,6 +142,21 @@ define DROPBEAR_INSTALL_TARGET_CMDS
 	ln -snf /var/run/dropbear $(TARGET_DIR)/etc/dropbear
 endef
 
+ifeq ($(BR2_PACKAGE_DROPBEAR_PREGENERATED_KEYS),y)
+DROPBEAR_DEPENDENCIES += host-dropbear
+define DROPBEAR_PREGENERATE_KEYS
+	rm -f $(TARGET_DIR)/etc/dropbear
+	mkdir -p $(TARGET_DIR)/etc/dropbear
+	$(HOST_DIR)/bin/dropbearkey -t rsa \
+		-f $(TARGET_DIR)/etc/dropbear/dropbear_rsa_host_key
+	$(HOST_DIR)/bin/dropbearkey -t ecdsa \
+		-f $(TARGET_DIR)/etc/dropbear/dropbear_ecdsa_host_key
+	$(HOST_DIR)/bin/dropbearkey -t ed25519 \
+		-f $(TARGET_DIR)/etc/dropbear/dropbear_ed25519_host_key
+endef
+DROPBEAR_POST_INSTALL_TARGET_HOOKS += DROPBEAR_PREGENERATE_KEYS
+endif
+
 HOST_DROPBEAR_MAKE = \
 	$(MAKE) \
 	PROGRAMS="dropbearkey"


### PR DESCRIPTION
By default dropbear generates its host keys on first startup (dropbear -R) and installs /etc/dropbear as a symlink to /var/run/dropbear, so the keys are not kept unless that path is backed by writable, persistent storage.

Add BR2_PACKAGE_DROPBEAR_PREGENERATED_KEYS to generate the RSA, ECDSA and ED25519 host keys at build time with the host dropbearkey and install them into a real /etc/dropbear directory in the image. This provides host keys that stay the same across reboots on read-only or volatile root filesystems (e.g. initramfs), with no key generation at runtime.

The option selects host-dropbear to provide dropbearkey.